### PR TITLE
feat: add support for orFilters in useCount and useList hooks

### DIFF
--- a/document-list/index.ts
+++ b/document-list/index.ts
@@ -29,6 +29,7 @@ export function useDocumentList<T>({
 
   return {
     ...listResource,
-    useCount: (options) => useCount(doctype, listOptions.filters, options),
+    useCount: (options) =>
+      useCount(doctype, listOptions.filters, listOptions.orFilters, options),
   };
 }

--- a/document-list/useCount.ts
+++ b/document-list/useCount.ts
@@ -7,12 +7,14 @@ const apiMethod = 'frappe.desk.reportview.get_count';
 export const useCount = <T>(
   doctype: string,
   filters?: ListFilter<T>,
+  orFilters?: ListFilter<T>,
   { cache, cacheTime, onSuccess, onError }: FetchOptions<number> = {},
 ) => {
   return useResource<ResponseMessage<number>, number>(apiMethod, {
     params: {
       doctype,
       filters: filters && JSON.stringify(tranformFilter(filters)),
+      or_filters: orFilters && JSON.stringify(tranformFilter(orFilters)),
     },
     cache,
     cacheTime,

--- a/list/index.ts
+++ b/list/index.ts
@@ -11,6 +11,7 @@ export interface UseListOptions<T> extends FetchOptions<T[]> {
   url: string;
   fields?: (keyof T)[] | '*';
   filters?: ListFilter<T>;
+  orFilters?: ListFilter<T>;
   group?: keyof T;
   sort?: {
     field: keyof T;
@@ -31,6 +32,7 @@ export function useList<T>({
   url,
   fields,
   filters,
+  orFilters,
   group,
   sort,
   start = 0,
@@ -45,6 +47,7 @@ export function useList<T>({
     () => ({
       fields: fields === '*' ? [fields] : fields,
       filters: filters && JSON.stringify(tranformFilter(filters)),
+      or_filters: orFilters && JSON.stringify(tranformFilter(orFilters)),
       group_by: group,
       order_by: sort && `${sort.field.toString()} ${sort.direction}`,
       limit,
@@ -55,6 +58,7 @@ export function useList<T>({
       JSON.stringify({
         fields,
         filters,
+        orFilters,
         group,
         sort,
         start,


### PR DESCRIPTION
Added orFilters parameter support to `useCount` and `useList` hooks. 
Enables OR-based document filtering using Frappe's or_filter logic.